### PR TITLE
Update "liferay-npm-bundler" to 2.16.1

### DIFF
--- a/slider/package.json
+++ b/slider/package.json
@@ -21,7 +21,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
     "@babel/preset-env": "^7.4.2",
     "babel-loader": "8.0.6",
-    "liferay-npm-bundler": "2.13.0",
+    "liferay-npm-bundler": "2.16.1",
     "liferay-npm-bundler-preset-liferay-dev": "^2.0.0",
     "metal-tools-soy": "4.3.2"
   }


### PR DESCRIPTION
Update "liferay-npm-bundler" to 2.16.1 to avoid issue https://github.com/liferay/liferay-js-toolkit/issues/407 in liferay-npm-bundler (Slider.es.js is not correctly generated in Windows)

For more information, see: https://issues.liferay.com/browse/LPP-35331?focusedCommentId=2040651&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2040651