### PR TITLE
Fix JS error when configuring this field in a rule

### DIFF
--- a/slider/src/main/resources/META-INF/resources/Slider/Slider.es.js
+++ b/slider/src/main/resources/META-INF/resources/Slider/Slider.es.js
@@ -32,6 +32,8 @@ class Slider extends Component {
 
 Slider.STATE = {
 
+    label: Config.string(),
+
     name: Config.string().required(),
 
     predefinedValue: Config.oneOfType([Config.number(), Config.string()]),


### PR DESCRIPTION
This fix prevents the following error from appearing:

message: "Failure: expected param label of type !goog.soy.data.SanitizedContent|string, but got undefined."
messagePattern: "Failure: expected param label of type !goog.soy.data.SanitizedContent|string, but got undefined."