### PR TITLE
Fixing apostrophe in package.json

### DIFF
--- a/slider/package.json
+++ b/slider/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build-soy && npm run build-js && liferay-npm-bundler",
     "build-js": "babel --source-maps -d build/resources/main/META-INF/resources src/main/resources/META-INF/resources",
-    "build-soy": "metalsoy --externalMsgFormat \"Liferay.Language.get(‘\\$2’)\" --soyDeps \"./node_modules/clay-*/src/**/*.soy\" \"./node_modules/com.liferay.dynamic.data.mapping.form.field.type/META-INF/resources/+(FieldBase|components)/**/*.soy\""
+    "build-soy": "metalsoy --externalMsgFormat \"Liferay.Language.get('\\$2')\" --soyDeps \"./node_modules/clay-*/src/**/*.soy\" \"./node_modules/com.liferay.dynamic.data.mapping.form.field.type/META-INF/resources/+(FieldBase|components)/**/*.soy\""
   },
   "version": "1.0.0",
   "devDependencies": {


### PR DESCRIPTION
I am getting the following error building a module with the tag msg in the soy template,
....
 Unexpected character '‘'
....
  247 |                 /** @desc  */
> 248 |                 var MSG_EXTERNAL_5218691681679081610 = Liferay.Language.get(‘choose-options’);